### PR TITLE
Fix the deployment script.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,8 @@ var gulp = require("gulp");
 var browserify = require('browserify');
 var watchify = require('watchify');
 var source = require('vinyl-source-stream');
-var uglify = require('gulp-uglify');
+//var uglify = require('gulp-uglify'); Deactivate uglify for now since we
+//cannot deploy with it.
 var webserver = require("gulp-webserver");
 var deploy = require("gulp-gh-pages");
 var rename = require("gulp-rename");
@@ -169,7 +170,7 @@ gulp.task("watch", ["assets","js:vendors", "config-dev", "watchify"],
 
 gulp.task("dist", ["assets", "js", "config-prod"], function() {
   return gulp.src(opt.outputFolder + "/js/*.js")
-    .pipe(uglify())
+    //.pipe(uglify())
     .pipe(gulp.dest(opt.outputFolder + "/js"));
 });
 


### PR DESCRIPTION
Using uglify, for whatever reason doesn't work. We tried to hunt down the
problem but without success: it seems that uglify isn't able to parse some
file, but we were not able to tell which one.

Because we still need to deploy new versions of daybed, I've deactivated the
minification process for now, until we figure out. See
https://github.com/spiral-project/formbuilder/issues/27
